### PR TITLE
feat: add distrobox ini for fedpkg

### DIFF
--- a/.scripts/distrobox/distrobox.ini
+++ b/.scripts/distrobox/distrobox.ini
@@ -1,0 +1,9 @@
+[fedpkg]
+additional_packages="fedora-packager copr-cli git"
+image=fedora:42
+init=true
+nvidia=false
+pull=true
+root=true
+replace=true
+start_now=false


### PR DESCRIPTION
Useful for doing fedora packaging on Atomic OS